### PR TITLE
LocalizedUniqueSlugField refactored

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,11 +194,10 @@ Besides ``LocalizedField``, there's also:
           .. code-block:: python
 
               from localized_fields import (LocalizedModel,
-                                            AtomicSlugRetryMixin,
                                             LocalizedField,
                                             LocalizedUniqueSlugField)
 
-              class MyModel(AtomicSlugRetryMixin, LocalizedModel):
+              class MyModel(LocalizedModel):
                    title = LocalizedField()
                    slug = LocalizedUniqueSlugField(populate_from='title')
 

--- a/localized_fields/mixins.py
+++ b/localized_fields/mixins.py
@@ -1,38 +1,17 @@
-from django.db import transaction
-from django.conf import settings
-from django.db.utils import IntegrityError
-
+from django.core.checks import Warning
 
 class AtomicSlugRetryMixin:
-    """Makes :see:LocalizedUniqueSlugField work by retrying upon
-    violation of the UNIQUE constraint."""
+    """A Mixin keeped for backwards compatibility"""
 
-    def save(self, *args, **kwargs):
-        """Saves this model instance to the database."""
-
-        max_retries = getattr(
-            settings,
-            'LOCALIZED_FIELDS_MAX_RETRIES',
-            100
+    @classmethod
+    def check(cls, **kwargs):
+        errors = super().check(**kwargs)
+        errors.append(
+            Warning(
+                'localized_fields.AtomicSlugRetryMixin is deprecated',
+                hint='There is no need to use '
+                     'localized_fields.AtomicSlugRetryMixin',
+                obj=cls
+            )
         )
-
-        if not hasattr(self, 'retries'):
-            self.retries = 0
-
-        with transaction.atomic():
-            try:
-                return super().save(*args, **kwargs)
-            except IntegrityError as ex:
-                # this is as retarded as it looks, there's no
-                # way we can put the retry logic inside the slug
-                # field class... we can also not only catch exceptions
-                # that apply to slug fields... so yea.. this is as
-                # retarded as it gets... i am sorry :(
-                if 'slug' not in str(ex):
-                    raise ex
-
-                if self.retries >= max_retries:
-                    raise ex
-
-        self.retries += 1
-        return self.save()
+        return errors

--- a/tests/fake_model.py
+++ b/tests/fake_model.py
@@ -14,7 +14,7 @@ def define_fake_model(name='TestModel', fields=None):
 
     if fields:
         attributes.update(fields)
-    model = type(name, (AtomicSlugRetryMixin,LocalizedModel,), attributes)
+    model = type(name, (LocalizedModel,), attributes)
 
     return model
 


### PR DESCRIPTION
There is no need to inherit the model from `AtomicSlugRetryMixin`.
`AtomicSlugRetryMixin` class keeped for backwards compatibility.