### PR TITLE
Ability to deserialize string value

### DIFF
--- a/localized_fields/fields/localized_field.py
+++ b/localized_fields/fields/localized_field.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from django.conf import settings
 from django.db.utils import IntegrityError
 from django.utils import six, translation
@@ -114,7 +116,7 @@ class LocalizedField(HStoreField):
 
         return cls.attr_class(value)
 
-    def to_python(self, value: dict) -> LocalizedValue:
+    def to_python(self, value: Union[dict, str, None]) -> LocalizedValue:
         """Turns the specified database value into its Python
         equivalent.
 
@@ -127,7 +129,8 @@ class LocalizedField(HStoreField):
             A :see:LocalizedValue instance containing the
             data extracted from the database.
         """
-
+        # make deserialization if need by parent method
+        value = super(LocalizedField, self).to_python(value)
         if not value or not isinstance(value, dict):
             return self.attr_class()
 

--- a/tests/test_localized_field.py
+++ b/tests/test_localized_field.py
@@ -1,3 +1,4 @@
+import json
 from django.conf import settings
 from django.db.utils import IntegrityError
 from django.test import TestCase
@@ -231,6 +232,20 @@ class LocalizedFieldTestCase(TestCase):
 
         for lang_code, _ in settings.LANGUAGES:
             assert localized_value.get(lang_code) is None
+
+    @staticmethod
+    def test_to_python_str():
+        """Tests whether the :see:to_python function produces
+        the expected :see:LocalizedValue when it is
+        passed serialized string value."""
+
+        serialized_str = json.dumps(get_init_values())
+        localized_value = LocalizedField().to_python(serialized_str)
+        assert isinstance(localized_value, LocalizedValue)
+
+        for language, value in get_init_values().items():
+            assert localized_value.get(language) == value
+            assert getattr(localized_value, language) == value
 
     @staticmethod
     def test_get_prep_value():


### PR DESCRIPTION
As [django documentation](https://docs.djangoproject.com/en/1.10/howto/custom-model-fields/#converting-values-to-python-objects) says:

> ``to_python()`` is called by **deserialization** and during the clean() method used from forms.
> 
> As a general rule, ``to_python()`` should deal gracefully with any of the following arguments:
> 
> - An instance of the correct type 
> - **A string**
> - ``None`` (if the field allows ``null=True``)
> 
``to_python`` method should correctly handle ``str`` value as argument