### PR TITLE
Fix non-valid HTML tags attributes

### DIFF
--- a/localized_fields/templates/localized_fields/admin/widget.html
+++ b/localized_fields/templates/localized_fields/admin/widget.html
@@ -3,12 +3,12 @@
     <ul class="localized-fields-widget tabs">
     {% for widget in widget.subwidgets %}
         <li class="localized-fields-widget tab">
-            <a href="#{{ widget_id }}_{{ widget.attrs.lang_code }}">{{ widget.attrs.lang_name|capfirst }}</a>
+            <a href="#{{ widget_id }}_{{ widget.lang_code }}">{{ widget.lang_name|capfirst }}</a>
         </li>
     {% endfor %}
     </ul>
 {% for widget in widget.subwidgets %}
-    <div role="tabpanel" id="{{ widget_id }}_{{ widget.attrs.lang_code }}">
+    <div role="tabpanel" id="{{ widget_id }}_{{ widget.lang_code }}">
         {% include widget.template_name %}
     </div>
 {% endfor %}

--- a/localized_fields/templates/localized_fields/multiwidget.html
+++ b/localized_fields/templates/localized_fields/multiwidget.html
@@ -1,4 +1,4 @@
 {% for widget in widget.subwidgets %}
-<label for="{{ widget.attrs.id }}">{{ widget.attrs.lang_name }}</label>
+<label for="{{ widget.attrs.id }}">{{ widget.lang_name }}</label>
 {% include widget.template_name %}
 {% endfor %}

--- a/localized_fields/widgets.py
+++ b/localized_fields/widgets.py
@@ -23,8 +23,9 @@ class LocalizedFieldWidget(forms.MultiWidget):
         super().__init__(initial_widgets, *args, **kwargs)
 
         for ((lang_code, lang_name), widget) in zip(settings.LANGUAGES, self.widgets):
-            widget.attrs['lang_code'] = lang_code
-            widget.attrs['lang_name'] = lang_name
+            widget.attrs['lang'] = lang_code
+            widget.lang_code = lang_code
+            widget.lang_name = lang_name
 
     def decompress(self, value: LocalizedValue) -> List[str]:
         """Decompresses the specified value so
@@ -76,7 +77,12 @@ class LocalizedFieldWidget(forms.MultiWidget):
             else:
                 widget_attrs = final_attrs
             widget_attrs = self.build_widget_attrs(widget, widget_value, widget_attrs)
-            subwidgets.append(widget.get_context(widget_name, widget_value, widget_attrs)['widget'])
+            widget_context = widget.get_context(widget_name, widget_value, widget_attrs)['widget']
+            widget_context.update(dict(
+                lang_code=widget.lang_code,
+                lang_name=widget.lang_name
+            ))
+            subwidgets.append(widget_context)
         context['widget']['subwidgets'] = subwidgets
         return context
 

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -45,7 +45,7 @@ class LocalizedFieldWidgetTestCase(TestCase):
             assert not value
 
     @staticmethod
-    def test_get_context():
+    def test_get_context_required():
         """Tests whether the :see:get_context correctly
         handles 'required' attribute, separately for each subwidget."""
 
@@ -56,6 +56,21 @@ class LocalizedFieldWidgetTestCase(TestCase):
                                      attrs=dict(required=True))
         assert context['widget']['subwidgets'][0]['attrs']['required']
         assert 'required' not in context['widget']['subwidgets'][1]['attrs']
+
+    @staticmethod
+    def test_get_context_langs():
+        """Tests whether the :see:get_context contains 'lang_code' and
+        'lang_name' attribute for each subwidget."""
+
+        widget = LocalizedFieldWidget()
+        context = widget.get_context(name='test', value=LocalizedValue(),
+                                     attrs=dict())
+        subwidgets_context = context['widget']['subwidgets']
+        for widget, context in zip(widget.widgets, subwidgets_context):
+            assert 'lang_code' in context
+            assert 'lang_name' in context
+            assert widget.lang_code == context['lang_code']
+            assert widget.lang_name == context['lang_name']
 
     @staticmethod
     def test_render():


### PR DESCRIPTION
Fix #35 
After:
```
<label for="id_title_0">English</label>
<textarea name="title_0" id="id_title_0" rows="10" cols="40" lang="en">
</textarea>


<label for="id_title_1">Romanian</label>
<textarea name="title_1" id="id_title_1" rows="10" cols="40" lang="ro">
</textarea>


<label for="id_title_2">Dutch</label>
<textarea name="title_2" id="id_title_2" rows="10" cols="40" lang="nl">
</textarea>
```