### PR TITLE
LocalizedFieldsAdminMixin can be used with inlines

### DIFF
--- a/localized_fields/admin.py
+++ b/localized_fields/admin.py
@@ -1,5 +1,3 @@
-from django.contrib.admin import ModelAdmin
-
 from . import widgets
 from .fields import LocalizedField, LocalizedCharField, LocalizedTextField, \
     LocalizedFileField
@@ -13,7 +11,7 @@ FORMFIELD_FOR_LOCALIZED_FIELDS_DEFAULTS = {
 }
 
 
-class LocalizedFieldsAdminMixin(ModelAdmin):
+class LocalizedFieldsAdminMixin:
     """Mixin for making the fancy widgets work in Django Admin."""
 
     class Media:
@@ -30,7 +28,7 @@ class LocalizedFieldsAdminMixin(ModelAdmin):
     def __init__(self, *args, **kwargs):
         """Initializes a new instance of :see:LocalizedFieldsAdminMixin."""
 
-        super(LocalizedFieldsAdminMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         overrides = FORMFIELD_FOR_LOCALIZED_FIELDS_DEFAULTS.copy()
         overrides.update(self.formfield_overrides)
         self.formfield_overrides = overrides


### PR DESCRIPTION
LocalizedFieldsAdminMixin was inheriting from ModelAdmin. This means in a code like this

```python
class FooInline(LocalizedFieldsAdminMixin, admin.TabularMixin):
    pass
```

`__init__` was being resolved to `ModelAdmin.__init__` which is clearly wrong.