### PR TITLE
fix LocalizedValue.deconstruct (wrong module name)

### DIFF
--- a/localized_fields/value.py
+++ b/localized_fields/value.py
@@ -61,7 +61,7 @@ class LocalizedValue(dict):
             contained in this instance.
         """
 
-        path = 'localized_fields.localized_value.%s' % self.__class__.__name__
+        path = 'localized_fields.value.%s' % self.__class__.__name__
         return path, [self.__dict__], {}
 
     def _interpret_value(self, value):


### PR DESCRIPTION
`LocalizedValue.deconstruct` references a non-existing module. Without the patch it's impossible to create a valid migration involving `LocalizedValue` (e.g. as a default value of a field).