### PR TITLE
fix admin widget work with inline formsets

### DIFF
--- a/localized_fields/static/localized_fields/localized-fields-admin.css
+++ b/localized_fields/static/localized_fields/localized-fields-admin.css
@@ -32,7 +32,7 @@
     opacity: 1;
 }
 
-.localized-fields-widget.tabs .localized-fields-widget.tab a {
+.localized-fields-widget.tabs .localized-fields-widget.tab label {
     padding: 5px 10px;
     display: inline-block;
     text-decoration: none;

--- a/localized_fields/static/localized_fields/localized-fields-admin.js
+++ b/localized_fields/static/localized_fields/localized-fields-admin.js
@@ -1,10 +1,10 @@
 (function($) {
     var syncTabs = function(lang) {
-        $('.localized-fields-widget.tab a:contains("'+lang+'")').each(function(){
+        $('.localized-fields-widget.tab label:contains("'+lang+'")').each(function(){
             $(this).parents('.localized-fields-widget[role="tabs"]').find('.localized-fields-widget.tab').removeClass('active');
             $(this).parents('.localized-fields-widget.tab').addClass('active');
             $(this).parents('.localized-fields-widget[role="tabs"]').children('.localized-fields-widget [role="tabpanel"]').hide();
-            $($(this).attr('href')).show();
+            $('#'+$(this).attr('for')).show();
         });
     }
 
@@ -13,7 +13,7 @@
         // set first tab as active
         $('.localized-fields-widget[role="tabs"]').each(function () {
             $(this).find('.localized-fields-widget.tab:first').addClass('active');
-            $($(this).find('.localized-fields-widget.tab:first a').attr('href')).show();
+            $('#'+$(this).find('.localized-fields-widget.tab:first label').attr('for')).show();
         });
         // try set active last selected tab
         if (window.sessionStorage) {
@@ -23,7 +23,7 @@
             }
         }
 
-        $('.localized-fields-widget.tab a').click(function(event) {
+        $('.localized-fields-widget.tab label').click(function(event) {
             event.preventDefault();
             syncTabs(this.innerText);
             if (window.sessionStorage) {

--- a/localized_fields/templates/localized_fields/admin/widget.html
+++ b/localized_fields/templates/localized_fields/admin/widget.html
@@ -3,7 +3,7 @@
     <ul class="localized-fields-widget tabs">
     {% for widget in widget.subwidgets %}
         <li class="localized-fields-widget tab">
-            <a href="#{{ widget_id }}_{{ widget.lang_code }}">{{ widget.lang_name|capfirst }}</a>
+            <label for="{{ widget_id }}_{{ widget.lang_code }}">{{ widget.lang_name|capfirst }}</label>
         </li>
     {% endfor %}
     </ul>


### PR DESCRIPTION
use `label` tag + `for` attribute instead of `a` + `href` for properly work with inline formsets due [inlines.js](https://github.com/django/django/blob/master/django/contrib/admin/static/admin/js/inlines.js#L24) which works only with `id`, `name` and `for` attributes