### PR TITLE
fix admin widget tabs width in inline formset

### DIFF
--- a/localized_fields/static/localized_fields/localized-fields-admin.css
+++ b/localized_fields/static/localized_fields/localized-fields-admin.css
@@ -37,6 +37,7 @@
     display: inline-block;
     text-decoration: none;
     color: #fff;
+    width: initial;
 }
 
 .localized-fields-widget.tabs .localized-fields-widget.tab.active,


### PR DESCRIPTION
Before:
![Before image](https://i.imgur.com/10h407V.png)

After:
![After image](https://i.imgur.com/51EZF9o.png)