### PR TITLE
The deprecation package removes its unnecessary unittest2 dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Contributors
 ------------
 
 * `seroy <https://github.com/seroy/>`_
-* `unaizalakain <https://github.com/unaizalakain/>`_
+* `umazalakain <https://github.com/umazalakain/>`_
 
 Installation
 ------------

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,2 @@
 django-postgres-extra==1.22
-deprecation==2.0.3
+deprecation==2.0.7

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     install_requires=[
         'django-postgres-extra>=1.22',
         'Django>=1.11',
-        'deprecation==2.0.3'
+        'deprecation==2.0.7'
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
Building unittest2 with python 3.7 was giving problems and is unnecessary, in more recent versions `deprecation` removes this dependency. I also updated my name ^^