### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 4. Install the development/test dependencies:
 
-       λ pip install .[test] .[analysis]
+       λ pip install ".[test]" ".[analysis]"
 
 5. Run the tests:
 


### PR DESCRIPTION
The command fails for me in its current form. Adding double quotes to the arguments seems to solve the issue. 

```sh
$ pip install .[test] .[analysis]
zsh: no matches found: .[test]
```

