### PR TITLE
Fix callable default usage in admin forms

### DIFF
--- a/localized_fields/fields/field.py
+++ b/localized_fields/fields/field.py
@@ -11,27 +11,6 @@ from ..forms import LocalizedFieldForm
 from ..value import LocalizedValue
 
 
-class FormClassFactory:
-    """When mixing callables as defaults and localized fields, Django will
-    render the default language value in the input form of the admin interface,
-    causing the printed hidden value to be diff-ed with the value provided in
-    the form, instead of a real instance of LocalizedField."""
-
-    def __init__(self, form_class):
-        self.form_class = form_class
-
-    def produce(self, **kwargs):
-        """Remove the parameter which triggers the issue.
-
-        Django should be able to determine the initial value without
-        printing it. That's how it worked before without any problems
-        """
-        if kwargs.get("show_hidden_initial"):
-            del kwargs["show_hidden_initial"]
-
-        return self.form_class(**kwargs)
-
-
 class LocalizedField(HStoreField):
     """A field that has the same value in multiple languages.
 
@@ -241,7 +220,7 @@ class LocalizedField(HStoreField):
         """Gets the form field associated with this field."""
 
         defaults = dict(
-            form_class=FormClassFactory(LocalizedFieldForm).produce,
+            form_class=LocalizedFieldForm,
             required=False if self.blank else self.required,
         )
         defaults.update(kwargs)

--- a/localized_fields/fields/field.py
+++ b/localized_fields/fields/field.py
@@ -11,6 +11,27 @@ from ..forms import LocalizedFieldForm
 from ..value import LocalizedValue
 
 
+class FormClassFactory:
+    """When mixing callables as defaults and localized fields, Django will
+    render the default language value in the input form of the admin interface,
+    causing the printed hidden value to be diff-ed with the value provided in
+    the form, instead of a real instance of LocalizedField."""
+
+    def __init__(self, form_class):
+        self.form_class = form_class
+
+    def produce(self, **kwargs):
+        """Remove the parameter which triggers the issue.
+
+        Django should be able to determine the initial value without
+        printing it. That's how it worked before without any problems
+        """
+        if kwargs.get("show_hidden_initial"):
+            del kwargs["show_hidden_initial"]
+
+        return self.form_class(**kwargs)
+
+
 class LocalizedField(HStoreField):
     """A field that has the same value in multiple languages.
 
@@ -220,7 +241,7 @@ class LocalizedField(HStoreField):
         """Gets the form field associated with this field."""
 
         defaults = dict(
-            form_class=LocalizedFieldForm,
+            form_class=FormClassFactory(LocalizedFieldForm).produce,
             required=False if self.blank else self.required,
         )
         defaults.update(kwargs)

--- a/localized_fields/forms.py
+++ b/localized_fields/forms.py
@@ -33,6 +33,10 @@ class LocalizedFieldForm(forms.MultiValueField):
         """Initializes a new instance of :see:LocalizedFieldForm."""
 
         fields = []
+        """
+        Do not print initial value in html in the form of a hidden input. This will result in loss of information
+        """
+        kwargs["show_hidden_initial"] = False
 
         for lang_code, _ in settings.LANGUAGES:
             field_options = dict(

--- a/localized_fields/forms.py
+++ b/localized_fields/forms.py
@@ -33,9 +33,8 @@ class LocalizedFieldForm(forms.MultiValueField):
         """Initializes a new instance of :see:LocalizedFieldForm."""
 
         fields = []
-        """
-        Do not print initial value in html in the form of a hidden input. This will result in loss of information
-        """
+
+        # Do not print initial value in html in the form of a hidden input. This will result in loss of information
         kwargs["show_hidden_initial"] = False
 
         for lang_code, _ in settings.LANGUAGES:


### PR DESCRIPTION
When using callables as default values for admin forms, Django automatically prints them in html as strings in a hidden input form. Applying __str__ on a localize field will cause it to lose information, when the submitted form is processed. (the initial value will be a str instead of a LocalizedValue instance)

I disabled the option to print a hidden field with the default value and let django use its fallback behaviour, which worked until now on default values which are not callables.

#84 