### PR TITLE
Prevent accumulating redundant data

### DIFF
--- a/localized_fields/value.py
+++ b/localized_fields/value.py
@@ -128,9 +128,8 @@ class LocalizedValue(dict):
         target_languages = fallback_config.get(
             target_language, [settings.LANGUAGE_CODE]
         )
-        target_languages.insert(0, target_language)
 
-        for lang_code in target_languages:
+        for lang_code in [target_language] + target_languages:
             value = self.get(lang_code)
             if value:
                 return value or None


### PR DESCRIPTION
`value.translate()` used to accumulate the same `target_language` at each call. This was an issue only when `LOCALIZED_FIELDS_FALLBACKS` was used.

After a while from the moment of the start time 70% of the computation time of was being spent by the `translate()` alone:

![image](https://user-images.githubusercontent.com/6563639/100213523-64649a00-2f17-11eb-9b87-8071c1a0fad7.png)
