### PR TITLE
Fix tabs displaying in Django 5.x

### DIFF
--- a/localized_fields/static/localized_fields/localized-fields-admin.css
+++ b/localized_fields/static/localized_fields/localized-fields-admin.css
@@ -34,7 +34,7 @@
 
 .localized-fields-widget.tabs .localized-fields-widget.tab label {
     padding: 5px 10px;
-    display: inline-block;
+    display: inline;
     text-decoration: none;
     color: #fff;
     width: initial;


### PR DESCRIPTION
Before:
<img width="1527" alt="image" src="https://github.com/SectorLabs/django-localized-fields/assets/897927/e8cfa4f1-d40f-4bc3-baf0-141a5388a6e0">

After:
<img width="1033" alt="image" src="https://github.com/SectorLabs/django-localized-fields/assets/897927/91ffa558-e127-4155-8b2c-05fb6f6e8ed5">
